### PR TITLE
fix: fix animation error when first click + button

### DIFF
--- a/lib/components/MenuTabBar.dart
+++ b/lib/components/MenuTabBar.dart
@@ -170,8 +170,10 @@ class _MenuTabBar extends State<MenuTabBar> with TickerProviderStateMixin {
                       return new Padding(padding: EdgeInsets.only(bottom: snapshot.data), child:
                         new StreamBuilder(stream: _isActivated.stream, builder: (context, AsyncSnapshot snapshot){
                           return new FloatingActionButton(elevation: 0, onPressed: (){
-                            if(_isActivated.stream.value == 1) _moveButtonDown();
-                            else {
+                            _updateButtonPosition(0);
+                            if(_isActivated.stream.value == 1) {
+                              _moveButtonDown();
+                            } else {
                               _moveButtonUp();
                             }
                           }, child:


### PR DESCRIPTION
`_animationUp` and `_animationDown` is not initialized until we move the + button, which is the cause of issue #1 .

As they are initialized in `_updateButtonPosition()`, so i just pass 0 to initialize them when click.

issue #1 